### PR TITLE
feat: make polygon parts fail suspend the job (MAPCO-5528)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -71,6 +71,7 @@
       "merge": "JOB_DEFINITIONS_TASK_MERGE",
       "polygonParts": "JOB_DEFINITIONS_TASK_POLYGON_PARTS",
       "finalize": "JOB_DEFINITIONS_TASK_FINALIZE"
-    }
+    },
+    "suspendingTaskTypes": "JOB_DEFINITIONS_SUSPENDING_TASKS"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -52,6 +52,7 @@
       "merge": "merge",
       "polygonParts": "polygon-parts",
       "finalize": "finalize"
-    }
+    },
+    "suspendingTaskTypes": ["polygon-parts"]
   }
 }

--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -63,7 +63,7 @@ Custom definitions
 
 {{
   /*
-  This function returns a yaml array of all the tasks types from jobDefinitions that has suspendJobOnFail: true
+  Returns a yaml array of all the tasks types from jobDefinitions that has suspendJobOnFail: true
   */
 }}
 {{- define "suspendingTaskTypes" -}}

--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -61,6 +61,11 @@ Custom definitions
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics .Values.global.metrics ) "context" . ) }}
 {{- end -}}
 
+{{
+  /*
+  This function returns a yaml array of all the tasks types from jobDefinitions that has suspendJobOnFail: true
+  */
+}}
 {{- define "suspendingTaskTypes" -}}
 {{- $jobDefinitions := include "common.jobDefinitions.merged" . | fromYaml -}}
 {{- $tasks := $jobDefinitions.tasks -}}

--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -61,11 +61,9 @@ Custom definitions
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics .Values.global.metrics ) "context" . ) }}
 {{- end -}}
 
-{{
-  /*
+{{/*
   Returns a yaml array of all the tasks types from jobDefinitions that has suspendJobOnFail: true
-  */
-}}
+  */}}
 {{- define "suspendingTaskTypes" -}}
 {{- $jobDefinitions := include "common.jobDefinitions.merged" . | fromYaml -}}
 {{- $tasks := $jobDefinitions.tasks -}}

--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -60,3 +60,15 @@ Custom definitions
 {{- define "common.metrics.merged" -}}
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics .Values.global.metrics ) "context" . ) }}
 {{- end -}}
+
+{{- define "suspendingTaskTypes" -}}
+{{- $jobDefinitions := include "common.jobDefinitions.merged" . | fromYaml -}}
+{{- $tasks := $jobDefinitions.tasks -}}
+{{- $result := list -}}
+{{- range $key, $task := $tasks -}}
+  {{- if and (hasKey $task "suspendJobOnFail") $task.suspendJobOnFail -}}
+    {{- $result = append $result $task.type -}}
+  {{- end -}}
+{{- end -}}
+{{- toYaml $result -}}
+{{- end -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- $configmapName := include "configmap.fullname" . }}
 {{- $jobDefinitions := (include "common.jobDefinitions.merged" .) | fromYaml }}
+{{- $suspendingTaskTypes := include "suspendingTaskTypes" . }}
 {{- $serviceUrls := (include "common.serviceUrls.merged" .) | fromYaml }}
 {{- $queue := .Values.env.queue }}
 {{- $tracing := (include "common.tracing.merged" .) | fromYaml }}
@@ -34,4 +35,5 @@ data:
   JOB_DEFINITIONS_TASK_MERGE: {{ $jobDefinitions.tasks.merge.type | quote }}
   JOB_DEFINITIONS_TASK_POLYGON_PARTS: {{ $jobDefinitions.tasks.polygonParts.type | quote }}
   JOB_DEFINITIONS_TASK_FINALIZE: {{ $jobDefinitions.tasks.finalize.type | quote }}
+  JOB_DEFINITIONS_SUSPENDING_TASKS: {{ $suspendingTaskTypes | toYaml | nindent 4 }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,10 +1,23 @@
 global:
-  cloudProvider: {}
+  cloudProvider:
+    dockerRegistryUrl: acrarolibotnonprod.azurecr.io
+    imagePullSecretName: acr-registry
+    flavor: openshift
   tracing: {}
   metrics: {}
   environment: ''
   jobDefinitions: {}
-  serviceUrls: {}
+  serviceUrls: 
+    catalogManager: "http://raster-core-dev-raster-catalog-manager-service"
+    jobTracker: "http://raster-core-dev-job-tracker-service"
+    mapServerPublicDNS: "https://tiles-dev.mapcolonies.net/api/raster/v1"
+    mapproxyApi: "http://raster-ingestion-dev-mapproxy-api-service"
+    jobManager: "http://common-job-manager-service"
+    heartbeatManager: "http://common-heartbeat-manager-service"
+    downloadServerPublicDNS: "https://download-dev.mapcolonies.net/api/raster/v1"
+    geoserverUrl: "http://raster-serving-dev-pp-geoserver-service/geoserver"
+    geoserverApiUrl: "http://raster-ingestion-dev-geoserver-api-service"
+    polygonPartsManager: "http://raster-ingestion-dev-polygon-parts-manager-service"
   ca:    
     secretName: ''
     path: '/usr/local/share/ca-certificates'
@@ -67,7 +80,7 @@ metrics:
 
 image:
   repository: job-tracker
-  tag: 'latest'
+  tag: 'nitzan-test'
   pullPolicy: IfNotPresent
 
 serviceUrls:
@@ -77,20 +90,30 @@ serviceUrls:
 jobDefinitions:
   jobs:
     new:
-      type: ''
+      type: "Ingestion_New"
     update:
-      type: ''
+      type: "Ingestion_Update"
     swapUpdate:
-      type: ''
+      type: "Ingestion_Swap_Update"
+    seed:
+      type: "TilesSeeding"
+    export:
+      type: "rasterTilesExporter"
   tasks:
     init:
-      type: ''
+      type: "init"
+      suspendJobOnFail: true
     merge:
-      type: ''
+      type: "tilesMerging"
     polygonParts:
-      type: ''
+      type: "polygon-parts"
+      suspendJobOnFail: true
     finalize:
-      type: ''
+      type: "finalize"
+    seed:
+      type: "TilesSeeding"
+    export:
+      type: "rasterTilesExporter"
 
 env:
   port: 80
@@ -116,7 +139,7 @@ resources:
       memory: 128Mi
 
 route:
-  enabled: false
+  enabled: true
   path: /
   host: 
   timeout:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,23 +1,10 @@
 global:
-  cloudProvider:
-    dockerRegistryUrl: acrarolibotnonprod.azurecr.io
-    imagePullSecretName: acr-registry
-    flavor: openshift
+  cloudProvider: {}
   tracing: {}
   metrics: {}
   environment: ''
   jobDefinitions: {}
-  serviceUrls: 
-    catalogManager: "http://raster-core-dev-raster-catalog-manager-service"
-    jobTracker: "http://raster-core-dev-job-tracker-service"
-    mapServerPublicDNS: "https://tiles-dev.mapcolonies.net/api/raster/v1"
-    mapproxyApi: "http://raster-ingestion-dev-mapproxy-api-service"
-    jobManager: "http://common-job-manager-service"
-    heartbeatManager: "http://common-heartbeat-manager-service"
-    downloadServerPublicDNS: "https://download-dev.mapcolonies.net/api/raster/v1"
-    geoserverUrl: "http://raster-serving-dev-pp-geoserver-service/geoserver"
-    geoserverApiUrl: "http://raster-ingestion-dev-geoserver-api-service"
-    polygonPartsManager: "http://raster-ingestion-dev-polygon-parts-manager-service"
+  serviceUrls: {}
   ca:    
     secretName: ''
     path: '/usr/local/share/ca-certificates'
@@ -80,7 +67,7 @@ metrics:
 
 image:
   repository: job-tracker
-  tag: 'nitzan-test'
+  tag: 'latest'
   pullPolicy: IfNotPresent
 
 serviceUrls:
@@ -90,29 +77,29 @@ serviceUrls:
 jobDefinitions:
   jobs:
     new:
-      type: "Ingestion_New"
+      type: ''
     update:
-      type: "Ingestion_Update"
+      type: ''
     swapUpdate:
-      type: "Ingestion_Swap_Update"
+      type: ''
     seed:
-      type: "TilesSeeding"
+      type: ''
     export:
-      type: "rasterTilesExporter"
+      type: ''
   tasks:
     init:
-      type: "init"
+      type: ''
     merge:
-      type: "tilesMerging"
+      type: ''
     polygonParts:
-      type: "polygon-parts"
+      type: ''
       suspendJobOnFail: false
     finalize:
-      type: "finalize"
+      type: ''
     seed:
-      type: "TilesSeeding"
+      type: ''
     export:
-      type: "rasterTilesExporter"
+      type: ''
 
 env:
   port: 80
@@ -138,7 +125,7 @@ resources:
       memory: 128Mi
 
 route:
-  enabled: true
+  enabled: false
   path: /
   host: 
   timeout:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -102,12 +102,11 @@ jobDefinitions:
   tasks:
     init:
       type: "init"
-      suspendJobOnFail: true
     merge:
       type: "tilesMerging"
     polygonParts:
       type: "polygon-parts"
-      suspendJobOnFail: true
+      suspendJobOnFail: false
     finalize:
       type: "finalize"
     seed:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -82,10 +82,6 @@ jobDefinitions:
       type: ''
     swapUpdate:
       type: ''
-    seed:
-      type: ''
-    export:
-      type: ''
   tasks:
     init:
       type: ''
@@ -95,10 +91,6 @@ jobDefinitions:
       type: ''
       suspendJobOnFail: false
     finalize:
-      type: ''
-    seed:
-      type: ''
-    export:
       type: ''
 
 env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@map-colonies/express-access-log-middleware": "^2.0.1",
         "@map-colonies/js-logger": "^1.0.1",
         "@map-colonies/mc-model-types": "^17.8.0",
-        "@map-colonies/mc-priority-queue": "^8.1.1",
+        "@map-colonies/mc-priority-queue": "^8.2.1",
         "@map-colonies/mc-utils": "^3.2.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
         "@map-colonies/read-pkg": "0.0.1",
@@ -4016,13 +4016,13 @@
       }
     },
     "node_modules/@map-colonies/mc-priority-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-priority-queue/-/mc-priority-queue-8.1.1.tgz",
-      "integrity": "sha512-M1uRtYA5SO5tQngzKbWNwqfUWSR2faeeZr8ADaNP9VY3Dko7Zf78FK/cyoSYzCJJVjHpw0GHzT3lzJwKJVV8Yw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-priority-queue/-/mc-priority-queue-8.2.1.tgz",
+      "integrity": "sha512-1LG3S8La6v2T0gth7eRSZ7HVenWAn9oDvECKPy7JTKDD9X6sUnObpHuZlO4nMOHCfKPZFz2cdtockT7+GRd/0w==",
       "license": "ISC",
       "peerDependencies": {
         "@map-colonies/js-logger": "^1.0.1",
-        "@map-colonies/mc-utils": "^3.0.0"
+        "@map-colonies/mc-utils": "^3.1.0"
       }
     },
     "node_modules/@map-colonies/mc-utils": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@map-colonies/express-access-log-middleware": "^2.0.1",
     "@map-colonies/js-logger": "^1.0.1",
     "@map-colonies/mc-model-types": "^17.8.0",
-    "@map-colonies/mc-priority-queue": "^8.1.1",
+    "@map-colonies/mc-priority-queue": "^8.2.1",
     "@map-colonies/mc-utils": "^3.2.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
     "@map-colonies/read-pkg": "0.0.1",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -33,6 +33,7 @@ export interface IJobDefinitionsConfig {
     merge: string;
     init: string;
   };
+  suspendingTaskTypes: string[];
 }
 
 export interface TaskNotificationRequest {

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -86,7 +86,7 @@ export class TasksManager {
 
   private async suspendJob(jobId: string): Promise<void> {
     await this.jobManager.updateJob(jobId, { status: OperationStatus.SUSPENDED });
-    this.logger.info({ msg: `Failed job: ${jobId}` });
+    this.logger.info({ msg: `Suspended job: ${jobId}` });
   }
 
   private async createTask(job: IJobResponse<unknown, unknown>, taskType: string): Promise<void> {

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -42,7 +42,11 @@ export class TasksManager {
       throw new NotFoundError(`Task ${taskId} not found`);
     }
     if (task.status === OperationStatus.FAILED) {
-      await this.failJob(task.jobId);
+      if (this.jobDefinitions.suspendingTaskTypes.includes(task.type)) {
+        await this.suspendJob(task.jobId);
+      } else {
+        await this.failJob(task.jobId);
+      }
     } else if (task.status === OperationStatus.COMPLETED) {
       const job = await this.jobManager.getJob(task.jobId);
       await this.handleCompletedTask(job, task);
@@ -77,6 +81,11 @@ export class TasksManager {
 
   private async failJob(jobId: string): Promise<void> {
     await this.jobManager.updateJob(jobId, { status: OperationStatus.FAILED });
+    this.logger.info({ msg: `Failed job: ${jobId}` });
+  }
+
+  private async suspendJob(jobId: string): Promise<void> {
+    await this.jobManager.updateJob(jobId, { status: OperationStatus.SUSPENDED });
     this.logger.info({ msg: `Failed job: ${jobId}` });
   }
 

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -42,11 +42,8 @@ export class TasksManager {
       throw new NotFoundError(`Task ${taskId} not found`);
     }
     if (task.status === OperationStatus.FAILED) {
-      if (this.jobDefinitions.suspendingTaskTypes.includes(task.type)) {
-        await this.suspendJob(task.jobId);
-      } else {
-        await this.failJob(task.jobId);
-      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this.jobDefinitions.suspendingTaskTypes.includes(task.type) ? await this.suspendJob(task.jobId) : await this.failJob(task.jobId);
     } else if (task.status === OperationStatus.COMPLETED) {
       const job = await this.jobManager.getJob(task.jobId);
       await this.handleCompletedTask(job, task);

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -93,7 +93,7 @@ describe('tasks', function () {
       expect(response).toSatisfyApiSpec();
     });
 
-    it('Should return 200 and fail job when getting failed task whose type is not in suspendedTaskTypes list', async () => {
+    it('Should return 200 and fail job when getting failed task whose type is not in suspendingTaskTypes list', async () => {
       // mocks
       const mockIngestionJob = getIngestionJobMock();
       const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.merge, status: OperationStatus.FAILED });
@@ -108,7 +108,7 @@ describe('tasks', function () {
       expect(response).toSatisfyApiSpec();
     });
 
-    it('Should return 200 and suspend job when getting failed task whose type is in suspendedTaskTypes list', async () => {
+    it('Should return 200 and suspend job when getting failed task whose type is in suspendingTaskTypes list', async () => {
       // mocks
       const mockIngestionJob = getIngestionJobMock();
       const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.polygonParts, status: OperationStatus.FAILED });

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -93,10 +93,10 @@ describe('tasks', function () {
       expect(response).toSatisfyApiSpec();
     });
 
-    it('Should return 200 and fail job when getting failed task', async () => {
+    it('Should return 200 and fail job when getting failed task whose type is not in suspendedTaskTypes list', async () => {
       // mocks
       const mockIngestionJob = getIngestionJobMock();
-      const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.polygonParts, status: OperationStatus.FAILED });
+      const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.merge, status: OperationStatus.FAILED });
       nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockMergeTask.id }).reply(200, [mockMergeTask]);
       nock(jobManagerConfigMock.jobManagerBaseUrl)
         .put(`/jobs/${mockIngestionJob.id}`, _.matches({ status: OperationStatus.FAILED }))
@@ -108,7 +108,22 @@ describe('tasks', function () {
       expect(response).toSatisfyApiSpec();
     });
 
-    it("Should return 200 when getting completed task who'se job have no init task", async () => {
+    it('Should return 200 and suspend job when getting failed task whose type is in suspendedTaskTypes list', async () => {
+      // mocks
+      const mockIngestionJob = getIngestionJobMock();
+      const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.polygonParts, status: OperationStatus.FAILED });
+      nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockMergeTask.id }).reply(200, [mockMergeTask]);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .put(`/jobs/${mockIngestionJob.id}`, _.matches({ status: OperationStatus.SUSPENDED }))
+        .reply(200);
+      // action
+      const response = await requestSender.handleTaskNotification(mockMergeTask.id);
+      // expectation
+      expect(response.status).toBe(200);
+      expect(response).toSatisfyApiSpec();
+    });
+
+    it('Should return 200 when getting completed task whose job have no init task', async () => {
       // mocks
       const mockIngestionJob = getIngestionJobMock();
       const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.merge, status: OperationStatus.COMPLETED });

--- a/tests/mocks/configMock.ts
+++ b/tests/mocks/configMock.ts
@@ -94,6 +94,7 @@ const registerDefaultConfig = (): void => {
         polygonParts: 'polygon-parts',
         finalize: 'finalize',
       },
+      suspendingTaskTypes: ['polygon-parts'],
     },
   };
 

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -224,7 +224,7 @@ describe('TasksManager', () => {
       await expect(tasksManager.handleTaskNotification(mergeTaskMock.id)).rejects.toThrow(NotFoundError);
     });
 
-    it("Should fail the job if the given task's status is 'Failed'", async () => {
+    it("Should fail the job if the given task's status is 'Failed' and task shouldn't suspend job", async () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock } = testContext;
       const ingestionJobMock = getIngestionJobMock();
@@ -235,6 +235,19 @@ describe('TasksManager', () => {
       await tasksManager.handleTaskNotification(mergeTaskMock.id);
       // expectation
       expect(mockUpdateJob).toHaveBeenCalledWith(ingestionJobMock.id, { status: OperationStatus.FAILED });
+    });
+
+    it("Should suspend the job if the given task's status is 'Failed' and task is in suspend job list", async () => {
+      // mocks
+      const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock } = testContext;
+      const ingestionJobMock = getIngestionJobMock();
+      const mergeTaskMock = getTaskMock(ingestionJobMock.id, { type: jobDefinitionsConfigMock.tasks.polygonParts, status: OperationStatus.FAILED });
+
+      mockFindTasks.mockResolvedValueOnce([mergeTaskMock]);
+      // action
+      await tasksManager.handleTaskNotification(mergeTaskMock.id);
+      // expectation
+      expect(mockUpdateJob).toHaveBeenCalledWith(ingestionJobMock.id, { status: OperationStatus.SUSPENDED });
     });
 
     it("Should throw IrrelevantOperationStatusError if the given task's status is neither 'Completed' nor 'Failed'", async () => {

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -237,7 +237,7 @@ describe('TasksManager', () => {
       expect(mockUpdateJob).toHaveBeenCalledWith(ingestionJobMock.id, { status: OperationStatus.FAILED });
     });
 
-    it("Should suspend the job if the given task's status is 'Failed' and task is in suspend job list", async () => {
+    it("Should suspend the job if the given task's status is 'Failed' and task is in suspendingTaskTypes list", async () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock } = testContext;
       const ingestionJobMock = getIngestionJobMock();


### PR DESCRIPTION
This feature was added to support the new "Suspended" job status from mc-priority-queue so when a polygon parts task fails, it won't fail the job and the ingestion process will proceed. Tests were added and the functionality was also tested manually (including with helm deployment). The default setting is that only polygon-parts tasks suspend the job on fail, but it's completely configurable.
Demo: 
[job-tracker.webm](https://github.com/user-attachments/assets/a02b620a-6af1-44a6-bd10-540c421b6387)
In this Demo you can see that when I notify the job tracker on a failed "polygon parts" task, it suspends the job, and when I notify on a failed "merge" task, it fails the job.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |
