### PR TITLE
fix: duplicate tasks (MAPCO-5853)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@godaddy/terminus": "^4.12.1",
         "@map-colonies/error-express-handler": "^2.1.0",
+        "@map-colonies/error-types": "^1.2.0",
         "@map-colonies/express-access-log-middleware": "^2.0.1",
         "@map-colonies/js-logger": "^1.0.1",
         "@map-colonies/mc-model-types": "^17.8.0",
@@ -3750,8 +3751,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@map-colonies/error-types/-/error-types-1.2.0.tgz",
       "integrity": "sha512-OS1iNNatEU59XIsT2cLbs89iNAef5CvttiRoUYr60NAE+JTFiF9Lm0QNDRFP9OJDiVcUQUr57xV3hiK4WgP2Xg==",
-      "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@map-colonies/error-express-handler": "^2.0.0",
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@godaddy/terminus": "^4.12.1",
     "@map-colonies/error-express-handler": "^2.1.0",
+    "@map-colonies/error-types": "^1.2.0",
     "@map-colonies/express-access-log-middleware": "^2.0.1",
     "@map-colonies/js-logger": "^1.0.1",
     "@map-colonies/mc-model-types": "^17.8.0",

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -138,6 +138,7 @@ export class TasksManager {
       await this.createTask(job, nextTaskType);
     } catch (error) {
       if (error instanceof ConflictError) {
+        this.logger.warn({ msg: `Detected an existing ${nextTaskType} task for job: ${job.id} - silently ignoring` });
         return;
       }
       throw error;

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -1,24 +1,23 @@
+import { ConflictError, NotFoundError } from '@map-colonies/error-types';
 import { Logger } from '@map-colonies/js-logger';
 import {
-  TaskHandler as QueueClient,
-  OperationStatus,
-  ICreateTaskBody,
-  ITaskResponse,
-  IFindTaskRequest,
-  JobManagerClient,
-  IJobResponse,
-} from '@map-colonies/mc-priority-queue';
-import { NotFoundError } from '@map-colonies/error-types';
-import {
   IngestionNewFinalizeTaskParams,
-  IngestionUpdateFinalizeTaskParams,
   IngestionSwapUpdateFinalizeTaskParams,
+  IngestionUpdateFinalizeTaskParams,
 } from '@map-colonies/mc-model-types';
+import {
+  ICreateTaskBody,
+  IFindTaskRequest,
+  IJobResponse,
+  ITaskResponse,
+  JobManagerClient,
+  OperationStatus,
+  TaskHandler as QueueClient,
+} from '@map-colonies/mc-priority-queue';
 import { inject, injectable } from 'tsyringe';
 import { SERVICES } from '../../common/constants';
-import { IConfig } from '../../common/interfaces';
-import { IJobDefinitionsConfig } from '../../common/interfaces';
 import { IrrelevantOperationStatusError } from '../../common/errors';
+import { IConfig, IJobDefinitionsConfig } from '../../common/interfaces';
 import { calculateTaskPercentage } from '../../utils/taskUtils';
 
 @injectable()
@@ -65,9 +64,7 @@ export class TasksManager {
       return;
     }
 
-    const taskHasSubsequentTask = task.type === this.jobDefinitions.tasks.merge || task.type === this.jobDefinitions.tasks.polygonParts;
-
-    if (job.completedTasks === job.taskCount && taskHasSubsequentTask) {
+    if (job.completedTasks === job.taskCount && this.taskHasSubsequentTask(task.type)) {
       await this.createNextTask(task.type, job);
     } else {
       this.logger.debug({ msg: 'Updating job percentage; no need for task creation' });
@@ -104,7 +101,12 @@ export class TasksManager {
         }
       }
     }
-    const createTaskBody: ICreateTaskBody<unknown> = { type: taskType, parameters: taskParameters };
+
+    const createTaskBody: ICreateTaskBody<unknown> = {
+      type: taskType,
+      parameters: taskParameters,
+      blockDuplication: this.taskBlocksDuplication(taskType),
+    };
     await this.jobManager.createTaskForJob(job.id, createTaskBody);
     this.logger.info({ msg: `Created ${taskType} task for job: ${job.id}` });
   }
@@ -131,12 +133,24 @@ export class TasksManager {
       default:
         return;
     }
-    const existingTask = await this.jobManager.findTasks({ jobId: job.id, type: nextTaskType });
-    if (existingTask) {
-      return;
+
+    try {
+      await this.createTask(job, nextTaskType);
+    } catch (error) {
+      if (error instanceof ConflictError) {
+        return;
+      }
+      throw error;
     }
-    await this.createTask(job, nextTaskType);
     const calculatedPercentage = calculateTaskPercentage(job.completedTasks, job.taskCount + 1);
     await this.updateJobPercentage(job.id, calculatedPercentage);
+  }
+
+  private taskHasSubsequentTask(taskType: string): boolean {
+    return [this.jobDefinitions.tasks.merge, this.jobDefinitions.tasks.polygonParts].includes(taskType);
+  }
+
+  private taskBlocksDuplication(taskType: string): boolean {
+    return [this.jobDefinitions.tasks.finalize, this.jobDefinitions.tasks.polygonParts].includes(taskType);
   }
 }

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -50,9 +50,6 @@ describe('tasks', function () {
         .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
         .reply(200, [mockInitTask]);
       nock(jobManagerConfigMock.jobManagerBaseUrl)
-        .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.polygonParts })
-        .reply(404);
-      nock(jobManagerConfigMock.jobManagerBaseUrl)
         .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.polygonParts }))
         .reply(201);
       nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockIngestionJob.id}`).reply(200);
@@ -79,9 +76,6 @@ describe('tasks', function () {
       nock(jobManagerConfigMock.jobManagerBaseUrl)
         .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
         .reply(200, [mockInitTask]);
-      nock(jobManagerConfigMock.jobManagerBaseUrl)
-        .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.finalize })
-        .reply(404);
       nock(jobManagerConfigMock.jobManagerBaseUrl)
         .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.finalize }))
         .reply(201);

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -63,6 +63,7 @@ describe('TasksManager', () => {
       expect(mockCreateTaskForJob).toHaveBeenCalledWith(ingestionJobMock.id, {
         parameters: { insertedToCatalog: false, insertedToGeoServer: false, insertedToMapproxy: false },
         type: jobDefinitionsConfigMock.tasks.finalize,
+        blockDuplication: true,
       });
       expect(mockUpdateJob).toHaveBeenCalledTimes(1);
     });
@@ -206,14 +207,17 @@ describe('TasksManager', () => {
       expect(mockCreateTaskForJob).toHaveBeenCalledWith(ingestionNewJobMock.id, {
         parameters: { insertedToMapproxy: false, insertedToGeoServer: false, insertedToCatalog: false },
         type: jobDefinitionsConfigMock.tasks.finalize,
+        blockDuplication: true,
       });
       expect(mockCreateTaskForJob).toHaveBeenCalledWith(ingestionUpdateJobMock.id, {
         parameters: { updatedInCatalog: false },
         type: jobDefinitionsConfigMock.tasks.finalize,
+        blockDuplication: true,
       });
       expect(mockCreateTaskForJob).toHaveBeenCalledWith(ingestionSwapJobMock.id, {
         parameters: { updatedInCatalog: false, updatedInMapproxy: false },
         type: jobDefinitionsConfigMock.tasks.finalize,
+        blockDuplication: true,
       });
     });
 


### PR DESCRIPTION
prevent duplicate polygon-parts/finalize tasks creation

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |
