### PR TITLE
fix: for failed export finalize task, fail the job

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@map-colonies/mc-priority-queue": "^8.2.1",
         "@map-colonies/mc-utils": "^3.2.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
-        "@map-colonies/raster-shared": "^1.9.0",
+        "@map-colonies/raster-shared": "^1.9.1",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "^6.0.0",
         "@opentelemetry/api": "^1.7.0",
@@ -4081,9 +4081,9 @@
       "dev": true
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.0.tgz",
-      "integrity": "sha512-hKiy6jXNdij52fo7HP9xJt3r30t61JrZlfSW7D5m/GCyE8pMCRyMFHRGwSoweQkP0vvF8wefIybLo7388PSmiw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.1.tgz",
+      "integrity": "sha512-yaJQ2JZoFkjlfPSkhEAr3qs8CDcBzD3Vv3AQzCcNd1P6vagU0p7F57NGOqgu28uwtsUZC5lwSNeRLnMYJidmpg==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@map-colonies/mc-priority-queue": "^8.2.1",
     "@map-colonies/mc-utils": "^3.2.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
-    "@map-colonies/raster-shared": "^1.9.0",
+    "@map-colonies/raster-shared": "^1.9.1",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "^6.0.0",
     "@opentelemetry/api": "^1.7.0",

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -203,7 +203,7 @@ export class TasksManager {
   private async handleExportFailure(task: ITaskResponse<unknown>): Promise<void> {
     this.logger.info({ msg: `Handling Export Failure with jobId: ${task.jobId}, and reason: ${task.reason}` });
 
-    if (task.type !== this.jobDefinitions.tasks.finalize) {
+    if (task.type === this.jobDefinitions.tasks.finalize) {
       const finalizeTask = exportFinalizeTaskParamsSchema.parse(task.parameters);
       if (finalizeTask.status === OperationStatus.FAILED) {
         await this.failJob(task.jobId, task.reason);

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -44,7 +44,7 @@ export class TasksManager {
     if (task.status === OperationStatus.FAILED) {
       const job = await this.getJob(task.jobId);
       if (job.type === this.jobDefinitions.jobs.export) {
-        await this.handleExportFailure(task.jobId, task.reason);
+        await this.handleExportFailure(task);
         return;
       } else if (this.jobDefinitions.suspendingTaskTypes.includes(task.type)) {
         await this.suspendJob(task.jobId, task.reason);
@@ -95,7 +95,7 @@ export class TasksManager {
 
   private async failJob(jobId: string, reason: string): Promise<void> {
     await this.jobManager.updateJob(jobId, { status: OperationStatus.FAILED, reason });
-    this.logger.info({ msg: `Failed job: ${jobId}` });
+    this.logger.info({ msg: `Failed job: ${jobId}`, reason });
   }
 
   private async completeJob(job: IJobResponse<unknown, unknown>): Promise<void> {
@@ -200,8 +200,17 @@ export class TasksManager {
     }
   }
 
-  private async handleExportFailure(jobId: string, reason: string): Promise<void> {
-    this.logger.info({ msg: `Handling Export Failure with jobId: ${jobId}, and reason: ${reason}` });
+  private async handleExportFailure(task: ITaskResponse<unknown>): Promise<void> {
+    this.logger.info({ msg: `Handling Export Failure with jobId: ${task.jobId}, and reason: ${task.reason}` });
+
+    if (task.type !== this.jobDefinitions.tasks.finalize) {
+      const finalizeTask = exportFinalizeTaskParamsSchema.parse(task.parameters);
+      if (finalizeTask.status === OperationStatus.FAILED) {
+        await this.failJob(task.jobId, task.reason);
+        return;
+      }
+    }
+
     const taskParameters: ExportFinalizeTaskParameters = { callbacksSent: false, status: OperationStatus.FAILED };
     const taskType = this.jobDefinitions.tasks.finalize;
     const createTaskBody: ICreateTaskBody<ExportFinalizeTaskParameters> = {
@@ -209,7 +218,7 @@ export class TasksManager {
       parameters: taskParameters,
       blockDuplication: this.taskBlocksDuplication(taskType, this.jobDefinitions.jobs.export),
     };
-    await this.jobManager.createTaskForJob(jobId, createTaskBody);
-    this.logger.info({ msg: `Created ${taskType} task for job: ${jobId}` });
+    await this.jobManager.createTaskForJob(task.jobId, createTaskBody);
+    this.logger.info({ msg: `Created ${taskType} task for job: ${task.jobId}` });
   }
 }

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -315,6 +315,7 @@ describe('TasksManager', () => {
 
       mockFindTasks.mockResolvedValueOnce([mergeTaskMock]);
       mockGetJob.mockResolvedValue(exportJobMock);
+
       // action
       await tasksManager.handleTaskNotification(mergeTaskMock.id);
       // expectation
@@ -323,6 +324,25 @@ describe('TasksManager', () => {
         type: jobDefinitionsConfigMock.tasks.finalize,
         blockDuplication: false,
       });
+    });
+
+    it('Should fail job on export failed finalize task', async () => {
+      // mocks
+      const { tasksManager, mockFindTasks, jobDefinitionsConfigMock, mockGetJob, mockUpdateJob } = testContext;
+      const exportJobMock = getExportJobMock();
+      const finalizeTaskMock = getTaskMock(exportJobMock.id, {
+        type: jobDefinitionsConfigMock.tasks.finalize,
+        status: OperationStatus.FAILED,
+        reason: 'some error message',
+        parameters: { callbacksSent: false, status: OperationStatus.FAILED },
+      });
+
+      mockFindTasks.mockResolvedValue([finalizeTaskMock]);
+      mockGetJob.mockResolvedValue(exportJobMock);
+      // action
+      await tasksManager.handleTaskNotification(finalizeTaskMock.id);
+      // expectation
+      expect(mockUpdateJob).toHaveBeenCalledWith(exportJobMock.id, { status: OperationStatus.FAILED, reason: finalizeTaskMock.reason });
     });
 
     it('Should create export successful finalize task on successful export', async () => {

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -328,7 +328,7 @@ describe('TasksManager', () => {
 
     it('Should fail job on export failed finalize task', async () => {
       // mocks
-      const { tasksManager, mockFindTasks, jobDefinitionsConfigMock, mockGetJob, mockUpdateJob } = testContext;
+      const { tasksManager, mockFindTasks, jobDefinitionsConfigMock, mockGetJob, mockUpdateJob, mockCreateTaskForJob } = testContext;
       const exportJobMock = getExportJobMock();
       const finalizeTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
@@ -343,6 +343,7 @@ describe('TasksManager', () => {
       await tasksManager.handleTaskNotification(finalizeTaskMock.id);
       // expectation
       expect(mockUpdateJob).toHaveBeenCalledWith(exportJobMock.id, { status: OperationStatus.FAILED, reason: finalizeTaskMock.reason });
+      expect(mockCreateTaskForJob).not.toHaveBeenCalled();
     });
 
     it('Should create export successful finalize task on successful export', async () => {


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


# Fix job failure handling for export operations

This PR fixes an issue with job tracking when export operations fail during the finalization step. Previously, we weren't properly terminating jobs when an export operation failed during finalization, which caused an infinite loop of:

1. Failed finalize task → 
2. Create new finalize task → 
3. Failed finalize task again

## Changes

Added logic to properly detect and handle failed export finalize tasks by:
- Correctly identifying when a finalize task has failed
- Explicitly calling `failJob()` with the appropriate error reason
- Terminating the execution flow to prevent creating additional tasks

This change ensures that when an export operation fails during finalization, we properly mark the entire job as failed and avoid the endless loop of creating new failed finalize tasks.