### PR TITLE
fix: Added support for polygon-parts task creation on init task completion

### DIFF
--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -60,6 +60,35 @@ describe('tasks', function () {
       expect(response).toSatisfyApiSpec();
     });
 
+    it('Should return 200 and create polygon-parts task when getting completed init task that finished after merge tasks', async () => {
+      // mocks
+      const mockIngestionJob = getIngestionJobMock();
+      const mockInitTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.init, status: OperationStatus.COMPLETED });
+      nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockInitTask.id }).reply(200, [mockInitTask]);
+
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .get(`/jobs/${mockIngestionJob.id}`)
+        .query({ shouldReturnTasks: false })
+        .reply(200, mockIngestionJob);
+
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
+        .reply(200, [mockInitTask]);
+
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.polygonParts }))
+        .reply(201);
+
+      nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockIngestionJob.id}`).reply(200);
+
+      // action
+      const response = await requestSender.handleTaskNotification(mockInitTask.id);
+
+      // expectation
+      expect(response.status).toBe(200);
+      expect(response).toSatisfyApiSpec();
+    });
+
     it('Should return 200 and create finalize task when getting polygon parts completed task', async () => {
       // mocks
       const mockIngestionJob = getIngestionJobMock();

--- a/tests/unit/tasks/models/testCases.ts
+++ b/tests/unit/tasks/models/testCases.ts
@@ -1,0 +1,31 @@
+import { IJobResponse } from '@map-colonies/mc-priority-queue';
+import { getExportJobMock, getIngestionJobMock } from '../../../mocks/JobMocks';
+
+export interface PolygonPartsTaskCreationTestCase {
+  description: string;
+  getJobMock: (override?: Partial<IJobResponse<unknown, unknown>>) => IJobResponse<unknown, unknown>;
+  taskType: string;
+}
+
+export const polygonPartsTaskCreationTestCases: PolygonPartsTaskCreationTestCase[] = [
+  {
+    description: 'Completed merge task with Completed init task',
+    getJobMock: getIngestionJobMock,
+    taskType: 'merge',
+  },
+  {
+    description: 'Init task when completed after merge task',
+    getJobMock: getIngestionJobMock,
+    taskType: 'init',
+  },
+  {
+    description: 'Completed merge task with Completed init task',
+    getJobMock: getExportJobMock,
+    taskType: 'export',
+  },
+  {
+    description: 'Init task when completed after merge task',
+    getJobMock: getExportJobMock,
+    taskType: 'init',
+  },
+];


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


Further  information:

**Problem**
We discovered an edge case when tilesMerging/tilesExporting tasks finished before the init task, causing issues with the workflow sequence.

**Solution**
Modified the task completion logic to ensure that when an init task finishes, we also properly create the corresponding polygon-parts task (if all other tilesMerging/tilesExporting tasks completed as well).

**Testing**
Added comprehensive tests to verify proper polygon-parts task creation across different task completion scenarios, including this specific edge case.
