### PR TITLE
feat!: removed 'failed' export finalize task and support one finalize …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@map-colonies/mc-priority-queue": "^8.2.1",
         "@map-colonies/mc-utils": "^3.2.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
-        "@map-colonies/raster-shared": "^1.9.1",
+        "@map-colonies/raster-shared": "^3.1.4",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "^6.0.0",
         "@opentelemetry/api": "^1.7.0",
@@ -4081,9 +4081,9 @@
       "dev": true
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.1.tgz",
-      "integrity": "sha512-yaJQ2JZoFkjlfPSkhEAr3qs8CDcBzD3Vv3AQzCcNd1P6vagU0p7F57NGOqgu28uwtsUZC5lwSNeRLnMYJidmpg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-3.1.4.tgz",
+      "integrity": "sha512-RDjwcT8AJ809Q72hK+mL5fs7WCEMqiz6ypZIjiW3HFDsI2zvFReQzUA5v6iw/tJut3oCF22nwxZMplYDSy0acg==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",
@@ -12894,6 +12894,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/geojson/-/geojson-0.5.0.tgz",
       "integrity": "sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@map-colonies/mc-priority-queue": "^8.2.1",
     "@map-colonies/mc-utils": "^3.2.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
-    "@map-colonies/raster-shared": "^1.9.1",
+    "@map-colonies/raster-shared": "^3.1.4",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "^6.0.0",
     "@opentelemetry/api": "^1.7.0",

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -15,7 +15,7 @@ import {
   TaskHandler as QueueClient,
 } from '@map-colonies/mc-priority-queue';
 import { inject, injectable } from 'tsyringe';
-import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams, exportFinalizeTaskParamsSchema } from '@map-colonies/raster-shared';
+import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams, exportFinalizeTaskParamsSchema, ExportFinalizeType } from '@map-colonies/raster-shared';
 import { JOB_COMPLETED_MESSAGE, SERVICES } from '../../common/constants';
 import { IrrelevantOperationStatusError } from '../../common/errors';
 import { IConfig, IJobDefinitionsConfig } from '../../common/interfaces';
@@ -72,7 +72,7 @@ export class TasksManager {
     if (task.type === this.jobDefinitions.tasks.finalize) {
       if (job.type === this.jobDefinitions.jobs.export) {
         const validFinalizeTaskParams = exportFinalizeTaskParamsSchema.parse(task.parameters);
-        if (validFinalizeTaskParams.type === 'ErrorCallback') {
+        if (validFinalizeTaskParams.type === ExportFinalizeType.Error_Callback) {
           return;
         }
       }
@@ -123,7 +123,7 @@ export class TasksManager {
         }
         case this.jobDefinitions.jobs.export: {
           (taskParameters as ExportFinalizeFullProcessingParams) = {
-            type: 'FullProcessing',
+            type: ExportFinalizeType.Full_Processing,
             gpkgModified: false,
             gpkgUploadedToS3: false,
             callbacksSent: false,
@@ -206,7 +206,7 @@ export class TasksManager {
 
   private async handleExportFailure(task: ITaskResponse<unknown>): Promise<void> {
     this.logger.info({ msg: `Handling Export Failure with jobId: ${task.jobId}, and reason: ${task.reason}` });
-    const taskParameters: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+    const taskParameters: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback };
     const taskType = this.jobDefinitions.tasks.finalize;
     const createTaskBody: ICreateTaskBody<ExportFinalizeErrorCallbackParams> = {
       type: taskType,

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -15,7 +15,12 @@ import {
   TaskHandler as QueueClient,
 } from '@map-colonies/mc-priority-queue';
 import { inject, injectable } from 'tsyringe';
-import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams, exportFinalizeTaskParamsSchema, ExportFinalizeType } from '@map-colonies/raster-shared';
+import {
+  ExportFinalizeErrorCallbackParams,
+  ExportFinalizeFullProcessingParams,
+  exportFinalizeTaskParamsSchema,
+  ExportFinalizeType,
+} from '@map-colonies/raster-shared';
 import { JOB_COMPLETED_MESSAGE, SERVICES } from '../../common/constants';
 import { IrrelevantOperationStatusError } from '../../common/errors';
 import { IConfig, IJobDefinitionsConfig } from '../../common/interfaces';

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -44,9 +44,11 @@ export class TasksManager {
     const job = await this.getJob(task.jobId);
     switch (task.status) {
       case OperationStatus.FAILED:
-        this.jobDefinitions.suspendingTaskTypes.includes(task.type)
-          ? await this.suspendJob(task.jobId, task.reason)
-          : await this.failJob(task.jobId, task.reason);
+        if (this.jobDefinitions.suspendingTaskTypes.includes(task.type)) {
+          await this.suspendJob(task.jobId, task.reason);
+        } else {
+          await this.failJob(task.jobId, task.reason);
+        }
         if (job.type === this.jobDefinitions.jobs.export && task.type !== this.jobDefinitions.tasks.finalize) {
           await this.handleExportFailure(task);
         }
@@ -71,8 +73,8 @@ export class TasksManager {
       if (job.type === this.jobDefinitions.jobs.export) {
         const validFinalizeTaskParams = exportFinalizeTaskParamsSchema.parse(task.parameters);
         if (validFinalizeTaskParams.type === 'ErrorCallback') {
-return;
-}
+          return;
+        }
       }
       await this.completeJob(job);
       return;

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -15,7 +15,7 @@ import {
   TaskHandler as QueueClient,
 } from '@map-colonies/mc-priority-queue';
 import { inject, injectable } from 'tsyringe';
-import { ExportFinalizeTaskParameters, exportFinalizeTaskParamsSchema } from '@map-colonies/raster-shared';
+import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams } from '@map-colonies/raster-shared';
 import { JOB_COMPLETED_MESSAGE, SERVICES } from '../../common/constants';
 import { IrrelevantOperationStatusError } from '../../common/errors';
 import { IConfig, IJobDefinitionsConfig } from '../../common/interfaces';
@@ -41,21 +41,21 @@ export class TasksManager {
     if (!task) {
       throw new NotFoundError(`Task ${taskId} not found`);
     }
-    if (task.status === OperationStatus.FAILED) {
-      const job = await this.getJob(task.jobId);
-      if (job.type === this.jobDefinitions.jobs.export) {
-        await this.handleExportFailure(task);
-        return;
-      } else if (this.jobDefinitions.suspendingTaskTypes.includes(task.type)) {
-        await this.suspendJob(task.jobId, task.reason);
-      } else {
-        await this.failJob(task.jobId, task.reason);
-      }
-    } else if (task.status === OperationStatus.COMPLETED) {
-      const job = await this.jobManager.getJob(task.jobId);
-      await this.handleCompletedTask(job, task);
-    } else {
-      throw new IrrelevantOperationStatusError(`Expected to get a 'Completed' or 'Failed' task' but instead got '${task.status}'`);
+    const job = await this.getJob(task.jobId);
+    switch (task.status) {
+      case OperationStatus.FAILED:
+        this.jobDefinitions.suspendingTaskTypes.includes(task.type)
+          ? await this.suspendJob(task.jobId, task.reason)
+          : await this.failJob(task.jobId, task.reason);
+        if (job.type === this.jobDefinitions.jobs.export && task.type !== this.jobDefinitions.tasks.finalize) {
+          await this.handleExportFailure(task);
+        }
+        break;
+      case OperationStatus.COMPLETED:
+        await this.handleCompletedTask(job, task);
+        break;
+      default:
+        throw new IrrelevantOperationStatusError(`Expected to get a 'Completed' or 'Failed' task' but instead got '${task.status}'`);
     }
   }
 
@@ -68,7 +68,7 @@ export class TasksManager {
     }
     // Handle completed finalization task
     if (task.type === this.jobDefinitions.tasks.finalize) {
-      await this.handleCompletedFinalizeTask(job, task);
+      await this.completeJob(job);
       return;
     }
     if (this.shouldCreateNextTask(job, initTask)) {
@@ -78,19 +78,6 @@ export class TasksManager {
     this.logger.debug({ msg: `Updating job percentage; No subsequence task for taskType ${task.type}` });
     const calculatedPercentage = calculateTaskPercentage(job.completedTasks, job.taskCount);
     await this.updateJobPercentage(job.id, calculatedPercentage);
-  }
-
-  private async handleCompletedFinalizeTask(job: IJobResponse<unknown, unknown>, task: ITaskResponse<unknown>): Promise<void> {
-    if (job.type === this.jobDefinitions.jobs.export) {
-      const exportFinalizeTask = exportFinalizeTaskParamsSchema.parse(task.parameters);
-      // Handle completed finalization task of failed export job
-      if (exportFinalizeTask.status === OperationStatus.FAILED) {
-        await this.failJob(job.id, task.reason);
-        this.logger.debug({ msg: `Failed export job: ${job.id}` });
-        return;
-      }
-    }
-    await this.completeJob(job);
   }
 
   private async failJob(jobId: string, reason: string): Promise<void> {
@@ -127,11 +114,11 @@ export class TasksManager {
           break;
         }
         case this.jobDefinitions.jobs.export: {
-          (taskParameters as ExportFinalizeTaskParameters) = {
-            status: OperationStatus.COMPLETED,
-            callbacksSent: false,
+          (taskParameters as ExportFinalizeFullProcessingParams) = {
+            type: 'FullProcessing',
             gpkgModified: false,
             gpkgUploadedToS3: false,
+            callbacksSent: false,
           };
           break;
         }
@@ -143,6 +130,7 @@ export class TasksManager {
       parameters: taskParameters,
       blockDuplication: this.taskBlocksDuplication(taskType, job.type),
     };
+
     await this.jobManager.createTaskForJob(job.id, createTaskBody);
     this.logger.info({ msg: `Created ${taskType} task for job: ${job.id}` });
   }
@@ -166,10 +154,15 @@ export class TasksManager {
     switch (currentTaskType) {
       case this.jobDefinitions.tasks.init: // for cases where merge tasks completes before init task
       case this.jobDefinitions.tasks.merge:
-        nextTaskType = this.jobDefinitions.tasks.polygonParts;
-        break;
-      case this.jobDefinitions.tasks.polygonParts:
+        if (job.type !== this.jobDefinitions.jobs.export) {
+          // for cases that export tasks completes before init task
+          nextTaskType = this.jobDefinitions.tasks.polygonParts;
+          break;
+        }
+        nextTaskType = this.jobDefinitions.tasks.finalize; // temporary ! should be change for better handle
+        return;
       case this.jobDefinitions.tasks.export:
+      case this.jobDefinitions.tasks.polygonParts:
         nextTaskType = this.jobDefinitions.tasks.finalize;
         break;
       default:
@@ -203,18 +196,9 @@ export class TasksManager {
 
   private async handleExportFailure(task: ITaskResponse<unknown>): Promise<void> {
     this.logger.info({ msg: `Handling Export Failure with jobId: ${task.jobId}, and reason: ${task.reason}` });
-
-    if (task.type === this.jobDefinitions.tasks.finalize) {
-      const finalizeTask = exportFinalizeTaskParamsSchema.parse(task.parameters);
-      if (finalizeTask.status === OperationStatus.FAILED) {
-        await this.failJob(task.jobId, task.reason);
-        return;
-      }
-    }
-
-    const taskParameters: ExportFinalizeTaskParameters = { callbacksSent: false, status: OperationStatus.FAILED };
+    const taskParameters: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
     const taskType = this.jobDefinitions.tasks.finalize;
-    const createTaskBody: ICreateTaskBody<ExportFinalizeTaskParameters> = {
+    const createTaskBody: ICreateTaskBody<ExportFinalizeErrorCallbackParams> = {
       type: taskType,
       parameters: taskParameters,
       blockDuplication: this.taskBlocksDuplication(taskType, this.jobDefinitions.jobs.export),

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -176,12 +176,6 @@ describe('tasks', function () {
         type: jobDefinitionsConfigMock.tasks.init,
         status: OperationStatus.COMPLETED,
       });
-      const fullProcessingFinalizeTaskParams: ExportFinalizeFullProcessingParams = {
-        type: 'FullProcessing',
-        gpkgModified: false,
-        gpkgUploadedToS3: false,
-        callbacksSent: false,
-      };
 
       nock(jobManagerConfigMock.jobManagerBaseUrl).get(`/jobs/${mockExportJob.id}`).query({ shouldReturnTasks: false }).reply(200, mockExportJob);
       nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockInitTask.id }).reply(200, [mockInitTask]);

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -7,9 +7,9 @@ import { configMock } from '../../mocks/configMock';
 import { getApp } from '../../../src/app';
 import { IJobManagerConfig, IJobDefinitionsConfig } from '../../../src/common/interfaces';
 import { getExportJobMock, getIngestionJobMock, getTaskMock } from '../../mocks/JobMocks';
+import { calculateTaskPercentage } from '../../../src/utils/taskUtils';
 import { TasksRequestSender } from './helpers/requestSender';
 import { getTestContainerConfig, resetContainer } from './helpers/containerConfig';
-import { calculateTaskPercentage } from '../../../src/utils/taskUtils';
 
 describe('tasks', function () {
   let requestSender: TasksRequestSender;
@@ -156,9 +156,11 @@ describe('tasks', function () {
       };
       nock(jobManagerConfigMock.jobManagerBaseUrl).get(`/jobs/${mockExportJob.id}`).query({ shouldReturnTasks: false }).reply(200, mockExportJob);
       nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockInitTask.id }).reply(200, [mockInitTask]);
-      nock(jobManagerConfigMock.jobManagerBaseUrl).post(`/tasks/find`, { jobId: mockExportJob.id, type: mockInitTask.type }).reply(200, [mockInitTask]);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post(`/tasks/find`, { jobId: mockExportJob.id, type: mockInitTask.type })
+        .reply(200, [mockInitTask]);
       nock(jobManagerConfigMock.jobManagerBaseUrl).post(`/jobs/${mockExportJob.id}/tasks`, mockFullProcessFinalizeTaskParams).reply(201);
-      const taskPercentage = calculateTaskPercentage(mockExportJob.completedTasks, mockExportJob.taskCount + 1)
+      const taskPercentage = calculateTaskPercentage(mockExportJob.completedTasks, mockExportJob.taskCount + 1);
       nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockExportJob.id}`, { percentage: taskPercentage }).reply(200);
       // action
       const response = await requestSender.handleTaskNotification(mockInitTask.id);
@@ -173,7 +175,6 @@ describe('tasks', function () {
       const mockInitTask = getTaskMock(mockExportJob.id, {
         type: jobDefinitionsConfigMock.tasks.init,
         status: OperationStatus.COMPLETED,
-
       });
       const fullProcessingFinalizeTaskParams: ExportFinalizeFullProcessingParams = {
         type: 'FullProcessing',
@@ -181,14 +182,12 @@ describe('tasks', function () {
         gpkgUploadedToS3: false,
         callbacksSent: false,
       };
-      const mockFullProcessFinalizeTaskParams = {
-        parameters: fullProcessingFinalizeTaskParams,
-        type: jobDefinitionsConfigMock.tasks.finalize,
-        blockDuplication: false,
-      };
+
       nock(jobManagerConfigMock.jobManagerBaseUrl).get(`/jobs/${mockExportJob.id}`).query({ shouldReturnTasks: false }).reply(200, mockExportJob);
       nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockInitTask.id }).reply(200, [mockInitTask]);
-      nock(jobManagerConfigMock.jobManagerBaseUrl).post(`/tasks/find`, { jobId: mockExportJob.id, type: mockInitTask.type }).reply(200, [mockInitTask]);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post(`/tasks/find`, { jobId: mockExportJob.id, type: mockInitTask.type })
+        .reply(200, [mockInitTask]);
       const taskPercentage = calculateTaskPercentage(mockExportJob.completedTasks, mockExportJob.taskCount);
       nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockExportJob.id}`, { percentage: taskPercentage }).reply(200);
       // action
@@ -302,7 +301,7 @@ describe('tasks', function () {
         .reply(200, [mockInitTask]);
       nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockExportTask.id }).reply(200, [mockExportTask]);
       nock(jobManagerConfigMock.jobManagerBaseUrl).post(`/jobs/${mockExportJob.id}/tasks`, mockTaskParameters).reply(201);
-      const taskPercentage = calculateTaskPercentage(mockExportJob.completedTasks, mockExportJob.taskCount + 1)
+      const taskPercentage = calculateTaskPercentage(mockExportJob.completedTasks, mockExportJob.taskCount + 1);
       nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockExportJob.id}`, { percentage: taskPercentage }).reply(200);
       // action
       const response = await requestSender.handleTaskNotification(mockExportTask.id);

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -10,6 +10,7 @@ import { getExportJobMock, getIngestionJobMock, getTaskMock } from '../../mocks/
 import { calculateTaskPercentage } from '../../../src/utils/taskUtils';
 import { TasksRequestSender } from './helpers/requestSender';
 import { getTestContainerConfig, resetContainer } from './helpers/containerConfig';
+import { ExportFinalizeType } from '@map-colonies/raster-shared';
 
 describe('tasks', function () {
   let requestSender: TasksRequestSender;
@@ -144,7 +145,7 @@ describe('tasks', function () {
         status: OperationStatus.COMPLETED,
       });
       const fullProcessingFinalizeTaskParams: ExportFinalizeFullProcessingParams = {
-        type: 'FullProcessing',
+        type: ExportFinalizeType.Full_Processing,
         gpkgModified: false,
         gpkgUploadedToS3: false,
         callbacksSent: false,
@@ -201,7 +202,7 @@ describe('tasks', function () {
       });
 
       const mockExportErrorFinalizeTaskParams = {
-        parameters: { callbacksSent: false, type: 'ErrorCallback' },
+        parameters: { callbacksSent: false, type: ExportFinalizeType.Error_Callback },
         type: jobDefinitionsConfigMock.tasks.finalize,
         blockDuplication: false,
       };
@@ -219,7 +220,7 @@ describe('tasks', function () {
     it('Should return 200 and complete job when getting completed export finalize task', async () => {
       const mockExportJob = getExportJobMock();
       const fullProccessingFinalizeTaskParams: ExportFinalizeFullProcessingParams = {
-        type: 'FullProcessing',
+        type: ExportFinalizeType.Full_Processing,
         gpkgModified: true,
         gpkgUploadedToS3: true,
         callbacksSent: true,
@@ -249,7 +250,7 @@ describe('tasks', function () {
     it('Should return 200 and fail export job when error callback export finalize task type is failing', async () => {
       const mockExportJob = getExportJobMock();
 
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
       const mockFinalizeTask = getTaskMock(mockExportJob.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.FAILED,
@@ -277,7 +278,7 @@ describe('tasks', function () {
         status: OperationStatus.COMPLETED,
       });
       const fullProccessingFinalizeTaskParams: ExportFinalizeFullProcessingParams = {
-        type: 'FullProcessing',
+        type: ExportFinalizeType.Full_Processing,
         gpkgModified: false,
         gpkgUploadedToS3: false,
         callbacksSent: false,

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -1,9 +1,8 @@
 import nock from 'nock';
-import { ICreateJobBody, ICreateTaskBody, OperationStatus } from '@map-colonies/mc-priority-queue';
+import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import _ from 'lodash';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import jestOpenAPI from 'jest-openapi';
-import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams, ExportFinalizeTaskParameters } from '@map-colonies/raster-shared';
+import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams } from '@map-colonies/raster-shared';
 import { configMock } from '../../mocks/configMock';
 import { getApp } from '../../../src/app';
 import { IJobManagerConfig, IJobDefinitionsConfig } from '../../../src/common/interfaces';
@@ -37,58 +36,58 @@ describe('tasks', function () {
   });
 
   describe('Happy Path', function () {
-    // it('Should return 200 and create polygon parts task when getting tiles merging completed task', async () => {
-    //   // mocks
-    //   const mockIngestionJob = getIngestionJobMock();
-    //   const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.merge, status: OperationStatus.COMPLETED });
-    //   const mockInitTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.init, status: OperationStatus.COMPLETED });
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockMergeTask.id }).reply(200, [mockMergeTask]);
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl)
-    //     .get(`/jobs/${mockIngestionJob.id}`)
-    //     .query({ shouldReturnTasks: false })
-    //     .reply(200, mockIngestionJob);
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl)
-    //     .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
-    //     .reply(200, [mockInitTask]);
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl)
-    //     .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.polygonParts }))
-    //     .reply(201);
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockIngestionJob.id}`).reply(200);
-    //   // action
-    //   const response = await requestSender.handleTaskNotification(mockMergeTask.id);
-    //   // expectation
-    //   expect(response.status).toBe(200);
-    //   expect(response).toSatisfyApiSpec();
-    // });
+    it('Should return 200 and create polygon parts task when getting tiles merging completed task', async () => {
+      // mocks
+      const mockIngestionJob = getIngestionJobMock();
+      const mockMergeTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.merge, status: OperationStatus.COMPLETED });
+      const mockInitTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.init, status: OperationStatus.COMPLETED });
+      nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockMergeTask.id }).reply(200, [mockMergeTask]);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .get(`/jobs/${mockIngestionJob.id}`)
+        .query({ shouldReturnTasks: false })
+        .reply(200, mockIngestionJob);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
+        .reply(200, [mockInitTask]);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.polygonParts }))
+        .reply(201);
+      nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockIngestionJob.id}`).reply(200);
+      // action
+      const response = await requestSender.handleTaskNotification(mockMergeTask.id);
+      // expectation
+      expect(response.status).toBe(200);
+      expect(response).toSatisfyApiSpec();
+    });
 
-    // it('Should return 200 and create polygon-parts task when getting completed init task that finished after merge tasks', async () => {
-    //   // mocks
-    //   const mockIngestionJob = getIngestionJobMock();
-    //   const mockInitTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.init, status: OperationStatus.COMPLETED });
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockInitTask.id }).reply(200, [mockInitTask]);
+    it('Should return 200 and create polygon-parts task when getting completed init task that finished after merge tasks', async () => {
+      // mocks
+      const mockIngestionJob = getIngestionJobMock();
+      const mockInitTask = getTaskMock(mockIngestionJob.id, { type: jobDefinitionsConfigMock.tasks.init, status: OperationStatus.COMPLETED });
+      nock(jobManagerConfigMock.jobManagerBaseUrl).post('/tasks/find', { id: mockInitTask.id }).reply(200, [mockInitTask]);
 
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl)
-    //     .get(`/jobs/${mockIngestionJob.id}`)
-    //     .query({ shouldReturnTasks: false })
-    //     .reply(200, mockIngestionJob);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .get(`/jobs/${mockIngestionJob.id}`)
+        .query({ shouldReturnTasks: false })
+        .reply(200, mockIngestionJob);
 
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl)
-    //     .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
-    //     .reply(200, [mockInitTask]);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post('/tasks/find', { jobId: mockIngestionJob.id, type: jobDefinitionsConfigMock.tasks.init })
+        .reply(200, [mockInitTask]);
 
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl)
-    //     .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.polygonParts }))
-    //     .reply(201);
+      nock(jobManagerConfigMock.jobManagerBaseUrl)
+        .post(`/jobs/${mockIngestionJob.id}/tasks`, _.matches({ type: jobDefinitionsConfigMock.tasks.polygonParts }))
+        .reply(201);
 
-    //   nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockIngestionJob.id}`).reply(200);
+      nock(jobManagerConfigMock.jobManagerBaseUrl).put(`/jobs/${mockIngestionJob.id}`).reply(200);
 
-    //   // action
-    //   const response = await requestSender.handleTaskNotification(mockInitTask.id);
+      // action
+      const response = await requestSender.handleTaskNotification(mockInitTask.id);
 
-    //   // expectation
-    //   expect(response.status).toBe(200);
-    //   expect(response).toSatisfyApiSpec();
-    // });
+      // expectation
+      expect(response.status).toBe(200);
+      expect(response).toSatisfyApiSpec();
+    });
 
     it('Should return 200 and create finalize task when getting polygon parts completed task', async () => {
       // mocks

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -3,6 +3,7 @@ import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import _ from 'lodash';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams } from '@map-colonies/raster-shared';
+import { ExportFinalizeType } from '@map-colonies/raster-shared';
 import { configMock } from '../../mocks/configMock';
 import { getApp } from '../../../src/app';
 import { IJobManagerConfig, IJobDefinitionsConfig } from '../../../src/common/interfaces';
@@ -10,7 +11,6 @@ import { getExportJobMock, getIngestionJobMock, getTaskMock } from '../../mocks/
 import { calculateTaskPercentage } from '../../../src/utils/taskUtils';
 import { TasksRequestSender } from './helpers/requestSender';
 import { getTestContainerConfig, resetContainer } from './helpers/containerConfig';
-import { ExportFinalizeType } from '@map-colonies/raster-shared';
 
 describe('tasks', function () {
   let requestSender: TasksRequestSender;
@@ -250,7 +250,7 @@ describe('tasks', function () {
     it('Should return 200 and fail export job when error callback export finalize task type is failing', async () => {
       const mockExportJob = getExportJobMock();
 
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback };
       const mockFinalizeTask = getTaskMock(mockExportJob.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.FAILED,

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -323,11 +323,12 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, jobDefinitionsConfigMock, mockGetJob, mockUpdateJob, mockCreateTaskForJob } = testContext;
       const exportJobMock = getExportJobMock();
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
       const finalizeTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.FAILED,
         reason: 'some error message',
-        parameters: { callbacksSent: false, status: OperationStatus.FAILED },
+        parameters: mockExportErrorFinalizeTaskParams,
       });
 
       mockFindTasks.mockResolvedValue([finalizeTaskMock]);
@@ -389,11 +390,12 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.export,
         status: OperationStatus.FAILED,
         reason: 'some error message',
-        parameters: { callbacksSent: false, status: OperationStatus.FAILED },
+        parameters: mockExportErrorFinalizeTaskParams,
       });
 
       mockFindTasks.mockResolvedValue([exportTaskMock]);
@@ -409,11 +411,12 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.init,
         status: OperationStatus.FAILED,
         reason: 'some error message',
-        parameters: { callbacksSent: false, status: OperationStatus.FAILED },
+        parameters: mockExportErrorFinalizeTaskParams,
       });
 
       mockFindTasks.mockResolvedValue([exportTaskMock]);

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -311,7 +311,7 @@ describe('TasksManager', () => {
       await tasksManager.handleTaskNotification(exportTaskMock.id);
       // expectation
       const createTaskBody: ICreateTaskBody<ExportFinalizeErrorCallbackParams> = {
-        parameters: { callbacksSent: false, type: ExportFinalizeType.Error_Callback  },
+        parameters: { callbacksSent: false, type: ExportFinalizeType.Error_Callback },
         type: jobDefinitionsConfigMock.tasks.finalize,
         blockDuplication: false,
       };
@@ -322,7 +322,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, jobDefinitionsConfigMock, mockGetJob, mockUpdateJob, mockCreateTaskForJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback };
       const finalizeTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.FAILED,
@@ -389,7 +389,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.export,
         status: OperationStatus.FAILED,
@@ -410,7 +410,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.init,
         status: OperationStatus.FAILED,
@@ -431,7 +431,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.COMPLETED,

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -1,6 +1,6 @@
 import { ConflictError, NotFoundError } from '@map-colonies/error-types';
 import { ICreateTaskBody, OperationStatus } from '@map-colonies/mc-priority-queue';
-import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams } from '@map-colonies/raster-shared';
+import { ExportFinalizeErrorCallbackParams, ExportFinalizeFullProcessingParams, ExportFinalizeType } from '@map-colonies/raster-shared';
 import { registerDefaultConfig, clear as clearConfig } from '../../../mocks/configMock';
 import { JOB_COMPLETED_MESSAGE } from '../../../../src/common/constants';
 import { getExportJobMock, getIngestionJobMock, getTaskMock } from '../../../mocks/JobMocks';
@@ -311,7 +311,7 @@ describe('TasksManager', () => {
       await tasksManager.handleTaskNotification(exportTaskMock.id);
       // expectation
       const createTaskBody: ICreateTaskBody<ExportFinalizeErrorCallbackParams> = {
-        parameters: { callbacksSent: false, type: 'ErrorCallback' },
+        parameters: { callbacksSent: false, type: ExportFinalizeType.Error_Callback  },
         type: jobDefinitionsConfigMock.tasks.finalize,
         blockDuplication: false,
       };
@@ -322,7 +322,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, jobDefinitionsConfigMock, mockGetJob, mockUpdateJob, mockCreateTaskForJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
       const finalizeTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.FAILED,
@@ -359,7 +359,7 @@ describe('TasksManager', () => {
       expect(mockCreateTaskForJob).toHaveBeenCalledTimes(1);
 
       const fullProccessingFinalizeTaskType: ICreateTaskBody<ExportFinalizeFullProcessingParams> = {
-        parameters: { type: 'FullProcessing', callbacksSent: false, gpkgModified: false, gpkgUploadedToS3: false },
+        parameters: { type: ExportFinalizeType.Full_Processing, callbacksSent: false, gpkgModified: false, gpkgUploadedToS3: false },
         type: jobDefinitionsConfigMock.tasks.finalize,
         blockDuplication: false,
       };
@@ -389,7 +389,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.export,
         status: OperationStatus.FAILED,
@@ -410,7 +410,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.init,
         status: OperationStatus.FAILED,
@@ -431,7 +431,7 @@ describe('TasksManager', () => {
       // mocks
       const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
       const exportJobMock = getExportJobMock();
-      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: ExportFinalizeType.Error_Callback  };
       const exportTaskMock = getTaskMock(exportJobMock.id, {
         type: jobDefinitionsConfigMock.tasks.finalize,
         status: OperationStatus.COMPLETED,

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -6,7 +6,6 @@ import { JOB_COMPLETED_MESSAGE } from '../../../../src/common/constants';
 import { getExportJobMock, getIngestionJobMock, getTaskMock } from '../../../mocks/JobMocks';
 import { IrrelevantOperationStatusError } from '../../../../src/common/errors';
 import { setupTasksManagerTest, TasksModelTestContext } from './tasksManagerSetup';
-import { polygonPartsTaskCreationTestCases } from './testCases';
 
 describe('TasksManager', () => {
   let testContext: TasksModelTestContext;

--- a/tests/unit/tasks/models/tasksManager.spec.ts
+++ b/tests/unit/tasks/models/tasksManager.spec.ts
@@ -426,5 +426,26 @@ describe('TasksManager', () => {
       // expectation
       expect(mockUpdateJob).toHaveBeenCalledWith(exportJobMock.id, { status: OperationStatus.FAILED, reason: exportTaskMock.reason });
     });
+
+    it('Should not update job on a completed error callback export finalize task', async () => {
+      // mocks
+      const { tasksManager, mockFindTasks, mockUpdateJob, jobDefinitionsConfigMock, mockGetJob } = testContext;
+      const exportJobMock = getExportJobMock();
+      const mockExportErrorFinalizeTaskParams: ExportFinalizeErrorCallbackParams = { callbacksSent: false, type: 'ErrorCallback' };
+      const exportTaskMock = getTaskMock(exportJobMock.id, {
+        type: jobDefinitionsConfigMock.tasks.finalize,
+        status: OperationStatus.COMPLETED,
+        reason: 'some error message',
+        parameters: mockExportErrorFinalizeTaskParams,
+      });
+
+      mockFindTasks.mockResolvedValue([exportTaskMock]);
+      //mockFindTasks.mockResolvedValueOnce([finalizeTaskMock]);
+      mockGetJob.mockResolvedValue(exportJobMock);
+      // action
+      await tasksManager.handleTaskNotification(exportTaskMock.id);
+      // expectation
+      expect(mockUpdateJob).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
**Breaking changes:**

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

This pull request change the way export finalize job works:
old implementation would create an "finalize" task with status prop,
new implementation includes 2 different types in 'finalize' export job:
**1. 'ErrorCallback'
2. FullProccessing'**

Main changes are:
got rid of the 2 finalize task creation and now creates only 1 per export job + handle it's failed/completed notifications
