### PR TITLE
fix(deps): upgrade @map-colonies/raster-shared to ^8.3.0 (MAPCO-11282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@map-colonies/mc-utils": "^5.1.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "8.3.0-alpha.0",
+        "@map-colonies/raster-shared": "^8.3.0",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/telemetry": "^6.0.0",
@@ -3412,9 +3412,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0-alpha.0.tgz",
-      "integrity": "sha512-xcleqPf+KSOObCqHuKm1nng7WQRAZ0JrX12qe1U8pX8iijZ7pS7QMrHnPM7DFU5cxMoxkgnRC8hVzd1SMLiErQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0.tgz",
+      "integrity": "sha512-5faR0iBC9Dpxm7Z8fY+3d+5oolHqVk/urXeOq3nHuIEMOvwRT2TrTr9fmt6TK8DaCjyQXBeEU1nijvuPLHmrEw==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@map-colonies/mc-utils": "^5.1.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "8.3.0-alpha.0",
+    "@map-colonies/raster-shared": "^8.3.0",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/telemetry": "^6.0.0",


### PR DESCRIPTION
## Summary
MAPCO-11282 — upgrade `@map-colonies/raster-shared` to the official **v8.3.0** release.

`8.3.0-alpha.0` → `^8.3.0`

## Tests
Baseline captured on unmodified `origin/master` first, so a pre-existing failure couldn't be mistaken for a regression.

| | Baseline | After bump |
|---|---|---|
| Unit | 136 passed | 136 passed |
| Integration | 94 passed | 94 passed |

`package-lock.json` regenerated — installed version confirmed as `8.3.0`.
